### PR TITLE
Added ability for EigenBot to identify if an issue is private

### DIFF
--- a/eigenbot.js
+++ b/eigenbot.js
@@ -95,10 +95,15 @@ function respondWithIssue(msg, issueKey) {
     // Send info about the bug in the form of an embed to the Discord channel
     sendEmbed(msg, issue)
   }).catch(error => {
-    if (error && error.error && error.error.errorMessages && error.error.errorMessages.includes('Issue Does Not Exist')) {
-      replyNoMention(msg, 'No issue was found for ' + issueKey + '.')
-    }  else if (error.error.errorMessages.includes('You do not have the permission to see the specified issue.')) {
-      callback('Issue ' + issueKey + ' is private and you don\'t have permission to see it.');
+    if (error && error.error && error.error.errorMessages) {
+      if (error.error.errorMessages.includes('Issue Does Not Exist')) {
+        replyNoMention(msg, 'No issue was found for ' + issueKey + '.')
+      }  else if (error.error.errorMessages.includes('You do not have the permission to see the specified issue.')) {
+        callback('Issue ' + issueKey + ' is private and you don\'t have permission to see it.');
+      } else {
+        replyNoMention(msg, 'An unknown error has occurred.')
+        console.log(error)
+      }
     } else {
       replyNoMention(msg, 'An unknown error has occurred.')
       console.log(error)

--- a/eigenbot.js
+++ b/eigenbot.js
@@ -99,7 +99,7 @@ function respondWithIssue(msg, issueKey) {
       if (error.error.errorMessages.includes('Issue Does Not Exist')) {
         replyNoMention(msg, 'No issue was found for ' + issueKey + '.')
       }  else if (error.error.errorMessages.includes('You do not have the permission to see the specified issue.')) {
-        callback('Issue ' + issueKey + ' is private and you don\'t have permission to see it.');
+        replyNoMention(msg,'Issue ' + issueKey + ' is private and you don\'t have permission to see it.');
       } else {
         replyNoMention(msg, 'An unknown error has occurred.')
         console.log(error)

--- a/eigenbot.js
+++ b/eigenbot.js
@@ -97,6 +97,8 @@ function respondWithIssue(msg, issueKey) {
   }).catch(error => {
     if (error && error.error && error.error.errorMessages && error.error.errorMessages.includes('Issue Does Not Exist')) {
       replyNoMention(msg, 'No issue was found for ' + issueKey + '.')
+    }  else if (error.error.errorMessages.includes('You do not have the permission to see the specified issue.')) {
+      callback('Issue ' + issueKey + ' is private and you don\'t have permission to see it.');
     } else {
       replyNoMention(msg, 'An unknown error has occurred.')
       console.log(error)


### PR DESCRIPTION
This simply adds another check in order to tell if the bug report is private or not. I find it pretty useful, so decided to add it to EigenBot